### PR TITLE
close iframe tag

### DIFF
--- a/talktools.py
+++ b/talktools.py
@@ -25,7 +25,7 @@ def website(url, name=None, width=800, height=450):
                      simple_link(url, name),
                      '</div>'] )
 
-    html.append('<iframe src="%s"  width="%s" height="%s">' % 
+    html.append('<iframe src="%s"  width="%s" height="%s"></iframe>' %
                 (prefix(url), width, height))
     return HTML('\n'.join(html))
 


### PR DESCRIPTION
If you don't do so, nbviewer fails to show any document beyond the iframe tag. 

[This talk](http://nbviewer.ipython.org/github/llimllib/fantasypl/blob/7a1f9ad6ddbc917bd27813c7f4cbd45afcd156e5/talk/Fantasy%20Football%20Presentation.ipynb) demonstrates the problem. Scroll down to the bottom, and you'll see that the talk appears to end after the iframe.

After the fix, it looks like [this](http://nbviewer.ipython.org/github/llimllib/fantasypl/blob/master/talk/Fantasy%20Football%20Presentation.ipynb); you'll see it continues past the iframe.
